### PR TITLE
Use tinyglobby and fix CI

### DIFF
--- a/.github/workflows/ci-swa.yml
+++ b/.github/workflows/ci-swa.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
-  DEFAULT_INSTALL_SCRIPT: npm ci && npm exec playwright install
+  DEFAULT_INSTALL_SCRIPT: npm ci && npm exec playwright install && npm i -g azure-functions-core-tools@4 --unsafe-perm true
   PUBLIC_SWA: false
   CI: true
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
 				"es-toolkit": "^1.45.1",
 				"rolldown": "^1.0.0",
 				"rolldown-plugin-sourcemaps": "^0.1.2",
-				"set-cookie-parser": "^3.1.0"
+				"set-cookie-parser": "^3.1.0",
+				"tinyglobby": "^0.2.16"
 			},
 			"devDependencies": {
 				"@changesets/cli": "^2.30.0",
@@ -9089,6 +9090,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
 		"es-toolkit": "^1.45.1",
 		"rolldown": "^1.0.0",
 		"rolldown-plugin-sourcemaps": "^0.1.2",
-		"set-cookie-parser": "^3.1.0"
+		"set-cookie-parser": "^3.1.0",
+		"tinyglobby": "^0.2.16"
 	},
 	"files": [
 		"src"

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,10 +1,10 @@
-import { globSync } from 'glob';
 import { merge } from 'es-toolkit/object';
 import assert from 'node:assert';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { rolldown } from 'rolldown';
 import sourcemaps from 'rolldown-plugin-sourcemaps';
+import { globSync } from 'tinyglobby';
 
 /**
  * @typedef {import('@sveltejs/kit').Builder} Builder

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,7 +1,6 @@
 import { merge } from 'es-toolkit/object';
 import assert from 'node:assert';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { rolldown } from 'rolldown';
 import sourcemaps from 'rolldown-plugin-sourcemaps';
 import { globSync } from 'tinyglobby';
@@ -31,14 +30,13 @@ function defaultRolldownOptions() {
  */
 function prepareRolldownOptions(builder, outDir) {
 	const clientDir = builder.getClientDirectory();
+	const cwd = process.cwd();
 	const input = Object.fromEntries(
-		globSync(`${clientDir}/**/*.js`).map((file) => [
+		globSync(`${clientDir}/**/*.js`, { cwd }).map((file) => [
 			// This removes `src/` as well as the file extension from each
 			// file, so e.g. src/nested/foo.js becomes nested/foo
 			path.relative(clientDir, file.slice(0, file.length - path.extname(file).length)),
-			// This expands the relative paths to absolute paths, so e.g.
-			// src/nested/foo becomes /project/src/nested/foo.js
-			fileURLToPath(new URL(file, import.meta.url))
+			path.resolve(cwd, file)
 		])
 	);
 	/** @type RolldownOptions */

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import path from 'node:path';
 import { rolldown } from 'rolldown';
 import sourcemaps from 'rolldown-plugin-sourcemaps';
-import { globSync } from 'tinyglobby';
+import { convertPathToPattern, globSync } from 'tinyglobby';
 
 /**
  * @typedef {import('@sveltejs/kit').Builder} Builder
@@ -32,7 +32,7 @@ function prepareRolldownOptions(builder, outDir) {
 	const clientDir = builder.getClientDirectory();
 	const cwd = process.cwd();
 	const input = Object.fromEntries(
-		globSync(`${clientDir}/**/*.js`, { cwd }).map((file) => [
+		globSync(`${convertPathToPattern(clientDir)}/**/*.js`).map((file) => [
 			// This removes `src/` as well as the file extension from each
 			// file, so e.g. src/nested/foo.js becomes nested/foo
 			path.relative(clientDir, file.slice(0, file.length - path.extname(file).length)),


### PR DESCRIPTION
Hi @ktarmyshov ,
I know that a change should be small. I started with fixing glob dependency related errors only. But these are the following problems I experienced

- First of all, [tinnyglobby](https://npmx.dev/package/tinyglobby) is the smaller and faster alternative to [glob](https://npmx.dev/package/glob), [fast-glob](https://npmx.dev/package/fast-glob) or [globby](https://npmx.dev/package/globby) according to [e18e](https://e18e.dev/docs/replacements/globby.html#replacements-for-globby).
- But there is an issue with [absolute path calculation](https://github.com/kt-npm-modules/svelte-adapter-azure-swa/blob/efb94aa8c9a2ff72d9dbe57df81d45b6ecd2e632/src/client/index.js#L41) so I had to fix it otherwise the package will not work properly.
- The glob calculation is not functioning properly especially on windows due to slashes so I fixed it using [convertPathToPattern](https://superchupu.dev/tinyglobby/documentation#convertPathToPattern).
- Still, the CI is failing it too so much time to debug it especially the playwright web server, I had to debug it by following [this](https://github.com/microsoft/playwright/issues/28570#issuecomment-1850903996). The issue was the missing `azure-functions-core-tools`. So I had to modify the install script as below
```
  DEFAULT_INSTALL_SCRIPT: npm ci && npm exec playwright install && npm i -g azure-functions-core-tools@4 --unsafe-perm true
```

Due to these changes this size of this PR is bug. Please check and let me know. 

Thank you.