### PR TITLE
chore: set platform while configuring rolldown

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -47,6 +47,7 @@ function defaultRolldownOptions() {
 			format: 'es',
 			sourcemap: true
 		},
+		platform: 'node',
 		plugins: [
 			sourcemaps({ include: /./ }),
 			// Adapted from @sveltejs/adapter-node


### PR DESCRIPTION
Rolldown needs platform to be set as node for [generating require function](https://rolldown.rs/in-depth/bundling-cjs#require-external-modules) for commonjs dependencies. Otherwise, the build fails to get deployed. I observed this while I tried to compile build and deploy an application using [node-postgres](https://node-postgres.com/).

Please let me know, if a test case can be added covering this.

Thanks,
Sukesh